### PR TITLE
Add docker compose for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ You can run the API locally with Python or via Docker.
 
 2. Or use Docker Compose:
    - docker compose -f src/markitdown-api/docker-compose.yml up --build
+   - docker compose -f src/markitdown-api/docker-compose.development.yml up --build  
+     _(builds and runs from your local source code, not a remote registry)_
 
 3. Or build and run the Docker image manually:
    - docker build -t markitdown-api src/markitdown-api

--- a/src/markitdown-api/Dockerfile
+++ b/src/markitdown-api/Dockerfile
@@ -27,4 +27,4 @@ RUN mkdir -p uploads
 EXPOSE 8000
 
 # Run the application
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/markitdown-api/docker-compose.development.yml
+++ b/src/markitdown-api/docker-compose.development.yml
@@ -1,0 +1,9 @@
+﻿services:
+  markitdown-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      ENV: "development"
+    ports:
+      - "8000:8000"

--- a/src/markitdown-api/requirements.txt
+++ b/src/markitdown-api/requirements.txt
@@ -6,3 +6,4 @@ pydantic-settings
 markitdown
 uvicorn
 python-multipart
+gunicorn


### PR DESCRIPTION
Added an option to run `docker-compose` in development based on the local code.

**Additionally**
While trying to use the current `docker-compose.yml`, I couldn't get it to work. Therefore, I also made the following changes:
- Added `gunicorn` to requirements.txt
  - Fixes: `exec: "gunicorn": executable file not found in $PATH`
- Updated the ASGI app entrypoint from `main:app` → `app.main:app`
  - Fixes: `ERROR: Error loading ASGI app. Could not import module "main"`