### PR TITLE
Add the option to enable scalar through env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ You can run the API locally with Python or via Docker.
 
 2. Or use Docker Compose:
    - docker compose -f src/markitdown-api/docker-compose.yml up --build
+   - docker compose -f src/markitdown-api/docker-compose.development.yml up --build  
+     _(builds and runs from your local source code, not a remote registry)_
 
 3. Or build and run the Docker image manually:
    - docker build -t markitdown-api src/markitdown-api

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ curl -X POST "http://localhost:8000/convert-url" \
 - ENV: development|staging|production (affects CORS and trusted hosts)
 - PUBLIC_BASE_URL: optional public URL (e.g., https://api.example.com) used for docs server URL and TrustedHost in production
 - CORS_ORIGINS: comma-separated list of origins allowed for CORS
+- ENABLE_SCALAR: enable or disable Scalar UI/docs (default: `true`)
 
 ## Requirements
 

--- a/src/markitdown-api/Dockerfile
+++ b/src/markitdown-api/Dockerfile
@@ -27,4 +27,4 @@ RUN mkdir -p uploads
 EXPOSE 8000
 
 # Run the application
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/markitdown-api/app/core/settings.py
+++ b/src/markitdown-api/app/core/settings.py
@@ -19,6 +19,9 @@ class Settings(BaseSettings):
     # CORS
     CORS_ORIGINS: List[AnyHttpUrl] = Field(default_factory=list)
 
+    # Features
+    ENABLE_SCALAR: bool = True
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
 settings = Settings()

--- a/src/markitdown-api/app/main.py
+++ b/src/markitdown-api/app/main.py
@@ -43,14 +43,15 @@ if settings.ENV == "production" and settings.PUBLIC_BASE_URL:
 # Routes
 app.include_router(converter_router)
 
-@app.get("/scalar", include_in_schema=False)
-async def scalar_html(request: Request):
-    server_url = str(settings.PUBLIC_BASE_URL or request.base_url).rstrip("/")
-    return get_scalar_api_reference(
-        openapi_url=app.openapi_url,
-        title=app.title,
-        servers=[{"url": server_url, "description": f"{settings.ENV.capitalize()} server"}],
-    )
+if settings.ENABLE_SCALAR:
+    @app.get("/scalar", include_in_schema=False)
+    async def scalar_html(request: Request):
+        server_url = str(settings.PUBLIC_BASE_URL or request.base_url).rstrip("/")
+        return get_scalar_api_reference(
+            openapi_url=app.openapi_url,
+            title=app.title,
+            servers=[{"url": server_url, "description": f"{settings.ENV.capitalize()} server"}],
+        )
 
 # Meta & health
 @app.get("/")

--- a/src/markitdown-api/docker-compose.development.yml
+++ b/src/markitdown-api/docker-compose.development.yml
@@ -1,0 +1,9 @@
+﻿services:
+  markitdown-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      ENV: "development"
+    ports:
+      - "8000:8000"

--- a/src/markitdown-api/requirements.txt
+++ b/src/markitdown-api/requirements.txt
@@ -6,3 +6,4 @@ pydantic-settings
 markitdown
 uvicorn
 python-multipart
+gunicorn


### PR DESCRIPTION
This pull request resolves #14 by adding an environment variable to enable or disable the `/scalar` endpoint.